### PR TITLE
Ignoring package-lock.json for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ npm-debug.log
 # examples
 examples/FloatingLabel/node_modules/
 examples/FloatingLabel/lib/
+
+# package-lock.json
+# https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
+package-lock.json


### PR DESCRIPTION
Also locking down our versions a little more. [ch4884]

Further (optional) reading:
https://docs.npmjs.com/files/package-lock.json
https://docs.npmjs.com/files/package-locks
npm/npm#17979
npm/npm#18103

TL;DR: There is much community debate about this file.
